### PR TITLE
🐛 fix of "no match" error when two_true is false 

### DIFF
--- a/code.evaluation/evaluation/ec_data_compression.py
+++ b/code.evaluation/evaluation/ec_data_compression.py
@@ -23,7 +23,7 @@ def my_log(base_dir_join, file_name, message):
     storage_ext = '_log'
     type = check_existence(base_dir_join, storage_ext, file_name)
     with open(base_dir_join + file_name + storage_ext + '.txt', type) as logout:
-        print message
+        print (message)
         logout.write(str(message) + "\n")
 
 def store_base_data(base_dir_join, file_name, read_name, length, base_counts):

--- a/code.evaluation/evaluation/ec_evaluation.py
+++ b/code.evaluation/evaluation/ec_evaluation.py
@@ -326,7 +326,12 @@ if __name__ == "__main__":
             fastq_raw1_parser = SeqIO.parse(os.path.join(str(raw1_filename)), 'fastq')
             fastq_raw2_parser = SeqIO.parse(os.path.join(str(raw2_filename)), 'fastq')
 
-            handle_sequences(true_check, true_rec, two_raw, fastq_raw1_parser, fastq_raw2_parser, fastq_ec1_parser)
+            #Lines added to transform generator pobject into dictionaries
+            fastq_ec1 = make_dict(fastq_ec1_parser)
+            fastq_raw1 = make_dict(fastq_raw1_parser)
+
+            #Changed the names of the variables fastq_raw1_parser to fastq_raw1 and fastq_ec1_parser to fastq_ec1
+            handle_sequences(true_check, true_rec, two_raw, fastq_raw1, fastq_raw2_parser, fastq_ec1)
 
 
     message = "DONE: %s" % (cleaned_filename)


### PR DESCRIPTION
Added parentheses to print function and added conversion of parser variables into dictionaries. This makes the code compliant with python 3.